### PR TITLE
Increment build number and modify dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: ea43e9e4d1082073cbb0c587026e18579a14c67b5f31b9ca4c1f0adadf8ad6da
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win and vc<14]
 
 requirements:
@@ -33,13 +33,13 @@ requirements:
     - pybind11
     - eigen >=3.4.0
     - spdlog
-    - gems3k =>4.4.4
-    - thermofun >=0.5.4
+    - gems3k 
+    - thermofun 
 
   run:
     - python
-    - gems3k =>4.4.4
-    - thermofun >=0.5.4
+    - gems3k 
+    - thermofun 
 
 test:
   commands:


### PR DESCRIPTION
Updated build number and removed version constraints for gems3k and thermofun.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
